### PR TITLE
Bugfixed: paths treated as strings and syntax mistake

### DIFF
--- a/epic_kitchens/preprocessing/split_segments.py
+++ b/epic_kitchens/preprocessing/split_segments.py
@@ -70,7 +70,7 @@ def main(args):
 
     video_annotations = annotations[annotations[VIDEO_ID_COL] == args.video]
     for frame_dir, links_dir in zip(frame_dirs, links_dirs):
-        common_root = os.path.commonpath([frame_dir, links_dir])
+        common_root = os.path.commonpath([str(frame_dir), str(links_dir)])
         print(common_root)
         split_video_frames(modality, args.frame_format, video_annotations, links_dir, frame_dir)
 

--- a/epic_kitchens/video.py
+++ b/epic_kitchens/video.py
@@ -121,8 +121,8 @@ def _split_frames_by_segment(frame_format: str, frame_iterator, segment_dir: Pat
             target_frame_filename = frame_format % (frame_index - first_frame_index + 1)
             source_frame_path = video_dir.joinpath(source_frame_filename)
             segmented_frame_path = segment_dir.joinpath(target_frame_filename)
-            assert source_frame_path.exists(), f"{source_frame_path} does not exist"
-            if os.path.lexists(segmented_frame_path):
+            assert source_frame_path.exists(), "{source_frame_path} does not exist"
+            if os.path.lexists(str(segmented_frame_path)):
                 os.remove(str(segmented_frame_path))
             source_frame_relative_path = os.path.relpath(str(source_frame_path), start=str(segment_dir))
             os.symlink(str(source_frame_relative_path), str(segmented_frame_path), dir_fd=segment_dir_fd)


### PR DESCRIPTION
I'm using Python 3.5.2 and got errors about paths not being strings. Also there was a syntax mistake.