### PR TITLE
Pin imageio to version that doesn't break moviepy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ numpy==1.16.1
 pandas==0.24.1
 typing==3.6.6
 moviepy==0.2.3.5
+imageio==2.4.1
 ipython==7.2.0


### PR DESCRIPTION
Recently imageio has been upgraded and now throws an error
if imageio-ffmpeg isn't installed, even when you install it moviepy is
still broken, for the time being we need to depend on imageio<2.5.0 until
they release a version with less insane behaviour or moviepy is fixed.

This was reported in issue https://github.com/epic-kitchens/epic-lib/issues/69
and is currently breaking all CI tests.


@marc-moreaux do you want to see whether this fixes your issue?
You should just be able to `git clone` the repo and `pip install .` to install this branch